### PR TITLE
change from_logits

### DIFF
--- a/work/02_Submission/02_Submission.ipynb
+++ b/work/02_Submission/02_Submission.ipynb
@@ -219,7 +219,7 @@
     "    print(train_labels.shape)\n",
     "    model = create_model(input_shape=normalized_train_maps[0].shape,num_classes=len(failure_types))\n",
     "    model.compile(optimizer='adam',\n",
-    "              loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
+    "              loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=False),\n",
     "              metrics=['accuracy'])\n",
     "    \n",
     "    model.fit(normalized_train_maps, train_labels, epochs=2)\n",


### PR DESCRIPTION
Kerasのsparse_categorical_crossentropy損失関数がfrom_logits=Trueとして指定されているにも関わらず、モデルの出力層がSoftmax活性化関数を使用しているのでFalseに設定します